### PR TITLE
feat: Add Better Camera and Fullscreen features

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "re_adojas",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "private": true,
     "type": "module",
     "scripts": {
@@ -42,6 +42,7 @@
         "eslint-plugin-react-refresh": "^0.4.20",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
+        "terser": "^5.46.1",
         "typescript": "^5.8.3",
         "vite": "^7.1.2"
     }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
         "eslint-plugin-react-refresh": "^0.4.20",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
-        "terser": "^5.46.1",
         "typescript": "^5.8.3",
         "vite": "^7.1.2"
     }

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -441,6 +441,9 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                   {setting.type === "betterCamera" && (
                     <div className="flex items-center gap-3">
                       <button
+                        type="button"
+                        role="switch"
+                        aria-checked={settings.betterCamera}
                         onClick={() => updateSettings({ betterCamera: !settings.betterCamera })}
                         className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
                           settings.betterCamera ? "bg-purple-500" : "bg-slate-300 dark:bg-slate-600"

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -19,27 +19,53 @@ interface SettingsModalProps {
 export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const [searchQuery, setSearchQuery] = useState("")
   const [isFullscreen, setIsFullscreen] = useState(false)
+  const [fullscreenSupported, setFullscreenSupported] = useState(true)
   const { theme, setTheme } = useTheme()
   const { locale, setLocale, t, mounted } = useI18n()
   const { settings, updateSettings } = useAppSettings()
 
-  // Check fullscreen state on mount and when it changes
+  // Check fullscreen support and state on mount and when it changes
   useEffect(() => {
+    // Feature detection for Fullscreen API
+    const isSupported = !!(
+      document.documentElement.requestFullscreen ||
+      (document.documentElement as any).webkitRequestFullscreen ||
+      (document.documentElement as any).msRequestFullscreen
+    )
+    setFullscreenSupported(isSupported)
+    
     const checkFullscreen = () => {
-      setIsFullscreen(!!document.fullscreenElement)
+      setIsFullscreen(!!(document.fullscreenElement || (document as any).webkitFullscreenElement))
     }
     
     document.addEventListener('fullscreenchange', checkFullscreen)
+    document.addEventListener('webkitfullscreenchange', checkFullscreen)
     checkFullscreen()
-    return () => document.removeEventListener('fullscreenchange', checkFullscreen)
+    return () => {
+      document.removeEventListener('fullscreenchange', checkFullscreen)
+      document.removeEventListener('webkitfullscreenchange', checkFullscreen)
+    }
   }, [])
 
   const toggleFullscreen = async () => {
+    if (!fullscreenSupported) return
+    
     try {
-      if (!document.fullscreenElement) {
-        await document.documentElement.requestFullscreen()
+      const docEl = document.documentElement
+      const doc = document as any
+      
+      if (!document.fullscreenElement && !doc.webkitFullscreenElement) {
+        if (docEl.requestFullscreen) {
+          await docEl.requestFullscreen()
+        } else if (docEl.webkitRequestFullscreen) {
+          await docEl.webkitRequestFullscreen()
+        }
       } else {
-        await document.exitFullscreen()
+        if (document.exitFullscreen) {
+          await document.exitFullscreen()
+        } else if (doc.webkitExitFullscreen) {
+          await doc.webkitExitFullscreen()
+        }
       }
     } catch (error) {
       console.error('Fullscreen toggle failed:', error)
@@ -462,22 +488,34 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                   )}
 
                   {setting.type === "fullscreen" && (
-                    <Button
-                      onClick={toggleFullscreen}
-                      className="bg-purple-500 hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700 text-white flex items-center gap-2 w-full sm:w-auto"
-                    >
-                      {isFullscreen ? (
-                        <>
-                          <Minimize className="w-4 h-4" />
-                          {t("settings.fullscreen.exit")}
-                        </>
-                      ) : (
-                        <>
-                          <Maximize className="w-4 h-4" />
-                          {t("settings.fullscreen.enter")}
-                        </>
+                    <div className="space-y-2">
+                      <Button
+                        onClick={toggleFullscreen}
+                        disabled={!fullscreenSupported}
+                        className={`flex items-center gap-2 w-full sm:w-auto ${
+                          fullscreenSupported
+                            ? "bg-purple-500 hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700 text-white"
+                            : "bg-slate-300 dark:bg-slate-600 text-slate-500 dark:text-slate-400 cursor-not-allowed"
+                        }`}
+                      >
+                        {isFullscreen ? (
+                          <>
+                            <Minimize className="w-4 h-4" />
+                            {t("settings.fullscreen.exit")}
+                          </>
+                        ) : (
+                          <>
+                            <Maximize className="w-4 h-4" />
+                            {t("settings.fullscreen.enter")}
+                          </>
+                        )}
+                      </Button>
+                      {!fullscreenSupported && (
+                        <p className="text-xs text-amber-500 dark:text-amber-400">
+                          {t("settings.fullscreen.notSupported")}
+                        </p>
                       )}
-                    </Button>
+                    </div>
                   )}
                 </div>
               ))}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,13 +1,13 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useTheme } from "@/hooks/use-theme"
 import { useI18n } from "@/lib/i18n/context"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { X, Search, Monitor, Sun, Moon, Globe } from "lucide-react"
+import { X, Search, Monitor, Sun, Moon, Globe, Maximize, Minimize } from "lucide-react"
 import { locales, localeNames, type Locale } from "@/lib/i18n/config"
 import { useAppSettings } from "@/hooks/use-app-settings"
 
@@ -18,9 +18,33 @@ interface SettingsModalProps {
 
 export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const [searchQuery, setSearchQuery] = useState("")
+  const [isFullscreen, setIsFullscreen] = useState(false)
   const { theme, setTheme } = useTheme()
   const { locale, setLocale, t, mounted } = useI18n()
   const { settings, updateSettings } = useAppSettings()
+
+  // Check fullscreen state on mount and when it changes
+  useEffect(() => {
+    const checkFullscreen = () => {
+      setIsFullscreen(!!document.fullscreenElement)
+    }
+    
+    document.addEventListener('fullscreenchange', checkFullscreen)
+    checkFullscreen()
+    return () => document.removeEventListener('fullscreenchange', checkFullscreen)
+  }, [])
+
+  const toggleFullscreen = async () => {
+    try {
+      if (!document.fullscreenElement) {
+        await document.documentElement.requestFullscreen()
+      } else {
+        await document.exitFullscreen()
+      }
+    } catch (error) {
+      console.error('Fullscreen toggle failed:', error)
+    }
+  }
 
   if (!isOpen || !mounted) return null
 
@@ -89,6 +113,18 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
           title: t("settings.loadMethod.title"),
           description: t("settings.loadMethod.description"),
           type: "loadMethod",
+        },
+        {
+          id: "betterCamera",
+          title: t("settings.betterCamera.title"),
+          description: t("settings.betterCamera.description"),
+          type: "betterCamera",
+        },
+        {
+          id: "fullscreen",
+          title: t("settings.fullscreen.title"),
+          description: t("settings.fullscreen.description"),
+          type: "fullscreen",
         },
       ],
     },
@@ -400,6 +436,45 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                         </SelectItem>
                       </SelectContent>
                     </Select>
+                  )}
+
+                  {setting.type === "betterCamera" && (
+                    <div className="flex items-center gap-3">
+                      <button
+                        onClick={() => updateSettings({ betterCamera: !settings.betterCamera })}
+                        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                          settings.betterCamera ? "bg-purple-500" : "bg-slate-300 dark:bg-slate-600"
+                        }`}
+                      >
+                        <span
+                          className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                            settings.betterCamera ? "translate-x-6" : "translate-x-1"
+                          }`}
+                        />
+                      </button>
+                      <span className="text-sm text-slate-600 dark:text-slate-400">
+                        {settings.betterCamera ? t("settings.betterCamera.enabled") : t("settings.betterCamera.disabled")}
+                      </span>
+                    </div>
+                  )}
+
+                  {setting.type === "fullscreen" && (
+                    <Button
+                      onClick={toggleFullscreen}
+                      className="bg-purple-500 hover:bg-purple-600 dark:bg-purple-600 dark:hover:bg-purple-700 text-white flex items-center gap-2 w-full sm:w-auto"
+                    >
+                      {isFullscreen ? (
+                        <>
+                          <Minimize className="w-4 h-4" />
+                          {t("settings.fullscreen.exit")}
+                        </>
+                      ) : (
+                        <>
+                          <Maximize className="w-4 h-4" />
+                          {t("settings.fullscreen.enter")}
+                        </>
+                      )}
+                    </Button>
                   )}
                 </div>
               ))}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -27,15 +27,17 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   // Check fullscreen support and state on mount and when it changes
   useEffect(() => {
     // Feature detection for Fullscreen API
+    const docEl = document.documentElement as any
     const isSupported = !!(
-      document.documentElement.requestFullscreen ||
-      (document.documentElement as any).webkitRequestFullscreen ||
-      (document.documentElement as any).msRequestFullscreen
+      docEl.requestFullscreen ||
+      docEl.webkitRequestFullscreen ||
+      docEl.msRequestFullscreen
     )
     setFullscreenSupported(isSupported)
     
     const checkFullscreen = () => {
-      setIsFullscreen(!!(document.fullscreenElement || (document as any).webkitFullscreenElement))
+      const doc = document as any
+      setIsFullscreen(!!(document.fullscreenElement || doc.webkitFullscreenElement))
     }
     
     document.addEventListener('fullscreenchange', checkFullscreen)
@@ -51,7 +53,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
     if (!fullscreenSupported) return
     
     try {
-      const docEl = document.documentElement
+      const docEl = document.documentElement as any
       const doc = document as any
       
       if (!document.fullscreenElement && !doc.webkitFullscreenElement) {

--- a/src/hooks/use-app-settings.tsx
+++ b/src/hooks/use-app-settings.tsx
@@ -16,6 +16,7 @@ interface AppSettings {
   loadMethod: LoadMethodType
   hitsoundEnabled: boolean
   showStats: boolean // 是否使用 stats.js 面板
+  betterCamera: boolean // Better Camera: 镜头锁定在当前行星触发的 Tile 上
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -27,6 +28,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   loadMethod: "async", // Default to async loading
   hitsoundEnabled: true, // Default to enabled
   showStats: false, // Default to using default FPS panel
+  betterCamera: false, // Default to disabled - Better Camera mode
 }
 
 export function useAppSettings() {

--- a/src/lib/Player/Player.ts
+++ b/src/lib/Player/Player.ts
@@ -1704,20 +1704,6 @@ export class Player implements IPlayer {
         }
     }
     
-    // Better Camera: 当 Tile 变化时，瞬移镜头到新 Tile 中心
-    if (this.betterCameraEnabled && this.currentTileIndex !== previousTileIndex) {
-        const tile = this.levelData.tiles[this.currentTileIndex];
-        if (tile && tile.position) {
-            // 瞬移镜头到 Tile 中心
-            this.cameraPosition.x = tile.position[0];
-            this.cameraPosition.y = tile.position[1];
-            this.camera.position.x = this.cameraPosition.x;
-            this.camera.position.y = this.cameraPosition.y;
-            this.currentPivotPosition.x = tile.position[0];
-            this.currentPivotPosition.y = tile.position[1];
-        }
-    }
-    
     const tileIndex = this.currentTileIndex;
     
     // Check if we are past the last tile (Infinite Rotation)
@@ -1806,18 +1792,6 @@ export class Player implements IPlayer {
   private updateCameraFollow(delta: number): void {
       if (!this.planetRed || !this.planetBlue) return;
 
-      // Better Camera: 跳过所有摄像头事件处理，镜头已在 updatePlanetsPosition 中设置
-      if (this.betterCameraEnabled) {
-          // 只需更新视频背景和可见 Tile
-          if (this.videoMesh) {
-              this.videoMesh.position.x = this.camera.position.x;
-              this.videoMesh.position.y = this.camera.position.y;
-              this.videoMesh.rotation.z = 0;
-          }
-          this.updateVisibleTiles();
-          return;
-      }
-
       const settings = this.levelData.settings;
       const initialBPM = settings.bpm || 100;
       const initialSecPerBeat = 60 / initialBPM;
@@ -1830,7 +1804,7 @@ export class Player implements IPlayer {
       const currentTimeInSeconds = this.elapsedTime / 1000;
       const timeInLevel = currentTimeInSeconds - countdownDuration - (offset / 1000) - firstTileOffset;
 
-      // Process camera events
+      // Process camera events (still process even with Better Camera for zoom/rotation effects)
       const lastIdx = this.cameraController.getLastCameraTimelineIndex();
       const cameraTimeline = this.cameraController.getCameraTimeline();
       
@@ -1881,8 +1855,19 @@ export class Player implements IPlayer {
       // Get interpolated camera values
       const interpolated = this.cameraController.getInterpolatedValues(this.elapsedTime);
       
-      // Calculate target position
-      const target = this.cameraController.calculateTargetPosition(this.currentPivotPosition);
+      // Calculate target position - Better Camera only overrides position, not zoom/rotation
+      let target: { x: number; y: number };
+      if (this.betterCameraEnabled) {
+          // Better Camera: target is always the current tile center
+          const tile = this.levelData.tiles[this.currentTileIndex];
+          if (tile && tile.position) {
+              target = { x: tile.position[0], y: tile.position[1] };
+          } else {
+              target = this.cameraController.calculateTargetPosition(this.currentPivotPosition);
+          }
+      } else {
+          target = this.cameraController.calculateTargetPosition(this.currentPivotPosition);
+      }
 
       // Apply smoothing
       const currentBPM = (this.tileBPM && this.tileBPM[this.currentTileIndex]) || 100;

--- a/src/lib/Player/Player.ts
+++ b/src/lib/Player/Player.ts
@@ -22,6 +22,7 @@ export class Player implements IPlayer {
   private showTrail: boolean = false;
   private useWorker: boolean = true;
   private targetFramerate: TargetFramerateType = 'auto';
+  private betterCameraEnabled: boolean = false; // Better Camera: 锁定镜头到当前 Tile
   private animationId: number | null = null;
   private lastFrameTime: number = 0;
   private frameInterval: number = 0; // milliseconds between frames
@@ -668,6 +669,10 @@ export class Player implements IPlayer {
   public setTargetFramerate(framerate: TargetFramerateType): void {
     this.targetFramerate = framerate;
     this.updateFrameInterval();
+  }
+
+  public setBetterCamera(enabled: boolean): void {
+    this.betterCameraEnabled = enabled;
   }
 
   private updateFrameInterval(): void {
@@ -1675,6 +1680,9 @@ export class Player implements IPlayer {
         // Countdown phase - handled by standard logic
     }
     
+    // Store previous tile index for Better Camera detection
+    const previousTileIndex = this.currentTileIndex;
+    
     // Playing Phase
     if (this.tileStartTimes.length > 0) {
         if (timeInLevel < this.tileStartTimes[this.currentTileIndex]) {
@@ -1693,6 +1701,20 @@ export class Player implements IPlayer {
                    this.tileStartTimes[this.currentTileIndex + 1] <= timeInLevel) {
                 this.currentTileIndex++;
             }
+        }
+    }
+    
+    // Better Camera: 当 Tile 变化时，瞬移镜头到新 Tile 中心
+    if (this.betterCameraEnabled && this.currentTileIndex !== previousTileIndex) {
+        const tile = this.levelData.tiles[this.currentTileIndex];
+        if (tile && tile.position) {
+            // 瞬移镜头到 Tile 中心
+            this.cameraPosition.x = tile.position[0];
+            this.cameraPosition.y = tile.position[1];
+            this.camera.position.x = this.cameraPosition.x;
+            this.camera.position.y = this.cameraPosition.y;
+            this.currentPivotPosition.x = tile.position[0];
+            this.currentPivotPosition.y = tile.position[1];
         }
     }
     
@@ -1783,6 +1805,18 @@ export class Player implements IPlayer {
   
   private updateCameraFollow(delta: number): void {
       if (!this.planetRed || !this.planetBlue) return;
+
+      // Better Camera: 跳过所有摄像头事件处理，镜头已在 updatePlanetsPosition 中设置
+      if (this.betterCameraEnabled) {
+          // 只需更新视频背景和可见 Tile
+          if (this.videoMesh) {
+              this.videoMesh.position.x = this.camera.position.x;
+              this.videoMesh.position.y = this.camera.position.y;
+              this.videoMesh.rotation.z = 0;
+          }
+          this.updateVisibleTiles();
+          return;
+      }
 
       const settings = this.levelData.settings;
       const initialBPM = settings.bpm || 100;

--- a/src/lib/i18n/translations.ts
+++ b/src/lib/i18n/translations.ts
@@ -170,6 +170,7 @@ export const translations = {
         description: "点击进入全屏模式，再次点击退出全屏。",
         enter: "进入全屏",
         exit: "退出全屏",
+        notSupported: "您的浏览器不支持全屏功能",
       },
       themePreview: {
         title: "主题预览",
@@ -347,6 +348,7 @@ export const translations = {
         description: "Click to enter fullscreen mode, click again to exit.",
         enter: "Enter Fullscreen",
         exit: "Exit Fullscreen",
+        notSupported: "Your browser does not support fullscreen mode",
       },
       themePreview: {
         title: "Theme Preview",
@@ -524,6 +526,7 @@ export const translations = {
         description: "クリックしてフルスクリーンモードに入り、もう一度クリックして終了します。",
         enter: "フルスクリーンへ",
         exit: "フルスクリーン終了",
+        notSupported: "お使いのブラウザはフルスクリーン機能に対応していません",
       },
       themePreview: {
         title: "テーマプレビュー",

--- a/src/lib/i18n/translations.ts
+++ b/src/lib/i18n/translations.ts
@@ -159,6 +159,18 @@ export const translations = {
         async: "异步（推荐）",
         worker: "Worker（后台线程）",
       },
+      betterCamera: {
+        title: "Better Camera",
+        description: "启用后镜头将锁定在当前行星触发的砖块上，忽略关卡中所有摄像头移动事件。退出播放后生效。",
+        enabled: "已启用",
+        disabled: "已禁用",
+      },
+      fullscreen: {
+        title: "全屏模式",
+        description: "点击进入全屏模式，再次点击退出全屏。",
+        enter: "进入全屏",
+        exit: "退出全屏",
+      },
       themePreview: {
         title: "主题预览",
       },
@@ -324,6 +336,18 @@ export const translations = {
         async: "Async (Recommended)",
         worker: "Worker (Background Thread)",
       },
+      betterCamera: {
+        title: "Better Camera",
+        description: "When enabled, camera locks onto the current planet's tile, ignoring all camera movement events. Takes effect after exiting playback.",
+        enabled: "Enabled",
+        disabled: "Disabled",
+      },
+      fullscreen: {
+        title: "Fullscreen Mode",
+        description: "Click to enter fullscreen mode, click again to exit.",
+        enter: "Enter Fullscreen",
+        exit: "Exit Fullscreen",
+      },
       themePreview: {
         title: "Theme Preview",
       },
@@ -488,6 +512,18 @@ export const translations = {
         sync: "同期（UIをブロック）",
         async: "非同期（推奨）",
         worker: "ワーカー（バックグラウンドスレッド）",
+      },
+      betterCamera: {
+        title: "Better Camera",
+        description: "有効にすると、カメラが現在の惑星のタイルにロックされ、すべてのカメラ移動イベントが無視されます。再生終了後に反映されます。",
+        enabled: "有効",
+        disabled: "無効",
+      },
+      fullscreen: {
+        title: "フルスクリーンモード",
+        description: "クリックしてフルスクリーンモードに入り、もう一度クリックして終了します。",
+        enter: "フルスクリーンへ",
+        exit: "フルスクリーン終了",
       },
       themePreview: {
         title: "テーマプレビュー",


### PR DESCRIPTION
- Better Camera: Lock camera to current tile, ignoring all camera movement events
- Fullscreen: Toggle fullscreen mode from settings
- Add translations for zh-CN, en-US, ja-JP
- 我改个版本号不介意吧qwq

## Summary by Sourcery

Add configurable Better Camera playback behavior and a fullscreen toggle to the settings UI, wiring both into player behavior and localization, and bump the package version.

New Features:
- Introduce a Better Camera setting that locks the camera to the current tile during playback when enabled.
- Add a fullscreen mode toggle in the settings modal with live UI state feedback.
- Provide Better Camera and fullscreen translations for zh-CN, en-US, and ja-JP.

Enhancements:
- Persist Better Camera preference in app settings with a sensible default.
- Update player camera update logic to respect the Better Camera mode and bypass existing camera events when enabled.

Build:
- Bump package version to 1.0.4 and add terser as a development dependency.